### PR TITLE
Add property for preferGithubIssues

### DIFF
--- a/api-docs/_deconst.json
+++ b/api-docs/_deconst.json
@@ -1,5 +1,8 @@
 {
   "contentIDBase": "https://github.com/rackerlabs/docs-cloud-identity/",
-  "githubUrl": "https://github.com/rackerlabs/docs-cloud-identity/",
-  "githubBranch": "master"
+  "githubUrl": "https://github.com/rackerlabs/docs-rackspace/",
+  "githubBranch": "master",
+  "meta": {
+    "preferGithubIssues": true
+  }
 }


### PR DESCRIPTION
For Identity, this value is set to `true`  and the githbURL points to the docs-rackspace repo.   The reason:   Identity is a private repo, so not all contributors can access the repo.  To do:
