### PR TITLE
Fixed links in contents section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ These guidelines provide the general process for maintaining source code that bu
 Rackspace Cloud Identity developer documentation. 
 
 - [Project description](#project-description)
-- [Editing and adding content](#edit-or-add-content)
+- [Editing and adding content](#editing-and-adding-content)
 - [General style guidelines](#general-style-guidelines)
-- [Merging content](#merge-content)
-- [Previewing changes](#preview-your-changes)
+- [Merging content](#merging-content)
+- [Previewing changes](#previewing-your-changes)
 
 ##Project description
 <!-- Provide as little or as much information about architecture as needed to help 


### PR DESCRIPTION
If you change headers, have to update the links in the table of contents. 

Note:  GitHub doesn't generate the TOC for the .md files, but several options are available to automate the process.  See https://github.com/isaacs/github/issues/215.