### PR TITLE
Change list wording and update link to dev guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Rackspace Cloud Identity API documentation
 
-This repository contains the source files that generate the following API documentation: 
+This repository contains the source files that generate the following Cloud Identity API documentation: 
 
 * [Quickstart Guide](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#document-quickstart-guide)
-* [Cloud Identity Developer Guide](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/)
-* [Cloud Identity Developer API Reference](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#api-reference)
+* [Developer Guide](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#document-developer-guide)
+* [API Reference](https://developer.rackspace.com/docs/cloud-identity/v2/developer-guide/#api-reference)
 
 Updates pushed to the master branch of this repo are automatically built by using the 
 [Strider CI/CD build job](http://ci.deconst.horse/rackerlabs/docs-cloud-identity-2.0/). Successful builds are deployed to production.


### PR DESCRIPTION
I removed "Cloud Identity" from the second and third bullets, and instead put it at the end of the intro sentence. That change makes the bullet items more parallel. I also updated the link to the dev guide to go straight to the "Developer Guide" section of the doc page.