### PR TITLE
HK - Ignore links to twitter.

### DIFF
--- a/api-docs/conf.py
+++ b/api-docs/conf.py
@@ -344,3 +344,5 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 # texinfo_no_detailmenu = False
+
+linkcheck_ignore = [r'https?:\/\/(www.)?twitter.com.*']

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyenchant==1.6.8
 sphinxcontrib-spelling==4.1.0
 sphinx==1.5.1
 sphinx_rtd_theme>=0.1.9
+tox==2.6.0


### PR DESCRIPTION
Twitter now has a filter in place that will filter out all
requests that are not within a whitelist of supported browsers.
This results in a 400 being returned for any twitter links in our
docs and breaks the build.